### PR TITLE
[cmake] Implements a fix to issue #6

### DIFF
--- a/tiago_bringup/CMakeLists.txt
+++ b/tiago_bringup/CMakeLists.txt
@@ -9,9 +9,14 @@ foreach(dir config launch)
 endforeach(dir)
 
 #install udev rule for end-effector usb camera
-install(
+
+OPTION(BUILD_FOR_TIAGO "Build for the real robot" ON)
+
+IF (BUILD_FOR_TIAGO)
+  install(
     DIRECTORY
-        system/
+       system/
     DESTINATION /
     USE_SOURCE_PERMISSIONS
-)
+    )
+ENDIF(BUILD_FOR_TIAGO)


### PR DESCRIPTION
By default the behavior is the same than before.
Otherwise to avoid the installation:
```
 catkin_make install -DBUILD_FOR_TIAGO=FALSE
```
