### PR TITLE
fixing the file path using no-arm

### DIFF
--- a/tiago_bringup/launch/tiago_play_motion2.launch.py
+++ b/tiago_bringup/launch/tiago_play_motion2.launch.py
@@ -44,6 +44,10 @@ def launch_setup(context, *args, **kwargs):
     end_effector = read_launch_argument('end_effector', context)
     ft_sensor = read_launch_argument('ft_sensor', context)
 
+    if (arm == 'no-arm'):
+        end_effector = 'no-end-effector'
+        ft_sensor = 'no-ft-sensor'
+
     motions_file = 'tiago_motions_' + get_tiago_hw_suffix(arm=arm,
                                                           wrist_model=None,
                                                           end_effector=end_effector,


### PR DESCRIPTION
The motion file is incorrectly created when you use Tiago in Gazebo with the arm selected as 'no-arm'
```
[WARNING] [launch_ros.actions.node]: Parameter file path is not a file: /tiago_ws/install/tiago_bringup/share/tiago_bringup/config/motions/tiago_motions_no-arm_pal-gripper_schunk-ft.yaml
```
This PR fixes this path ignoring the end-effector and ft-sensor when no-arm is selected.