### PR TITLE
Fix Issue #27:  TF Transform Error for Sonar Sensor by Adding Fixed Joint for base_sonar_01_link

### DIFF
--- a/tiago_description/robots/tiago.urdf.xacro
+++ b/tiago_description/robots/tiago.urdf.xacro
@@ -137,6 +137,14 @@
   <!-- Base -->
   <xacro:include filename="$(find ${base_type}_description)/urdf/base/base_sensors.urdf.xacro" />
 
+    <!-- Fixed joint to mount the sonar sensor (base_sonar_01_link) -->
+  <joint name="sonar_mount_joint" type="fixed">
+    <origin xyz="0.2 0.0 0.15" rpy="0 0 0"/>
+    <parent link="base_link"/>
+    <child link="base_sonar_01_link"/>
+  </joint>
+
+
   <!-- Torso -->
   <xacro:include filename="$(find tiago_description)/urdf/torso/torso.urdf.xacro" />
 


### PR DESCRIPTION
**PR Title:**  
Fix TF Transform Error for Sonar Sensor by Adding Fixed Joint for base_sonar_01_link

---

**PR Description:**  

### Description
This pull request addresses Issue #27 by resolving the TF transform error where the sonar sensor frame (`base_sonar_01_link`) is not connected to the robot's TF tree. The error message was:

```
Error: /move_base Range sensor layer can't transform from map to base_sonar_01_link
```

The fix involves adding a fixed joint that attaches `base_sonar_01_link` to the `base_link` in the robot model.

### Changes Made
- **File Modified:** `tiago_description/robots/tiago.urdf.xacro`
- **Modification:** Inserted a fixed joint named `sonar_mount_joint` immediately after the base sensors are defined and before the torso is declared. The joint definition is as follows:
  ```xml
  <!-- Fixed joint to mount the sonar sensor (base_sonar_01_link) -->
  <joint name="sonar_mount_joint" type="fixed">
    <origin xyz="0.2 0.0 0.15" rpy="0 0 0"/>
    <parent link="base_link"/>
    <child link="base_sonar_01_link"/>
  </joint>
  ```
  This joint establishes the necessary connection in the TF tree.

### Testing
- Rebuilt the workspace using `colcon build --packages-select tiago_description`.
- Sourced the setup file and launched the robot state publisher:
  ```bash
  ros2 launch tiago_description robot_state_publisher.launch.py
  ```
- Verified with `ros2 run tf2_tools view_frames.py` that the transform from `base_link` to `base_sonar_01_link` is correctly published.

### Impact
This change ensures that the sonar sensor's frame is properly integrated into the TF tree, resolving the TF lookup errors encountered during simulation and enabling correct sensor data processing by the navigation stack.

---

Please review and merge if everything looks correct.